### PR TITLE
bootstrap fixes, new issues discovered

### DIFF
--- a/R/bootstrap_renyi.R
+++ b/R/bootstrap_renyi.R
@@ -8,10 +8,6 @@ bootstrap_renyi <- function(x,
                             ly,
                             q,
                             burn = 50,
-                            constx = 0,
-                            consty = 0,
-                            nreps = 2,
-                            shuffles = 6,
                             cl = NULL) {
 
   if (is.null(cl[[1]])) {
@@ -22,70 +18,19 @@ bootstrap_renyi <- function(x,
   bootx <- markov_boot_step(x, lx, burn)
   booty <- markov_boot_step(y, ly, burn)
 
-  if (shuffles > 1) {
-    if (is.null(constx) || is.null(consty)) {
-      # Lead = x
-      x_te <- calc_te_renyi(x = bootx,
-                            lx = lx,
-                            y = y,
-                            ly = ly,
-                            q = q)
+  # Lead = x
+  dteyx <- calc_te_renyi(x = bootx,
+                         lx = lx,
+                         y = y,
+                         ly = ly,
+                         q = q)
 
-      dteyx <- x_te - constx
-
-      # Lead = y
-      y_te <- calc_te_renyi(x = booty,
-                            lx = ly,
-                            y = x,
-                            ly = lx,
-                            q = q)
-
-      dtexy <- y_te - consty
-    } else {
-      constx <- shuffle_renyi(x = bootx,
-                              lx = lx,
-                              y = y,
-                              ly = ly,
-                              q = q,
-                              nreps = nreps,
-                              shuffles = shuffles,
-                              diff = TRUE,
-                              cl = cl)
-
-      consty <- shuffle_renyi(x = booty,
-                              lx = ly,
-                              y = x,
-                              ly = lx,
-                              q = q,
-                              nreps = nreps,
-                              shuffles = shuffles,
-                              diff = TRUE,
-                              cl = cl)
-
-      # Lead = x
-      x_te <- calc_te_renyi(x = bootx,
-                            lx = lx,
-                            y = y,
-                            ly = ly,
-                            q = q)
-
-      dteyx <- x_te - constx
-
-      # Lead = y
-      y_te <- calc_te_renyi(x = booty,
-                            lx = ly,
-                            y = x,
-                            ly = lx,
-                            q = q)
-
-      dtexy <- y_te - consty
-    }
-  } else {
-    # Lead = x
-    dteyx <- calc_te_renyi(x = bootx, lx = lx, y = y, ly = ly, q = q)
-    # Lead = y
-    dtexy <- calc_te_renyi(x = booty, lx = ly, y = x, ly = lx, q = q)
-  }
+  # Lead = y
+  dtexy <- calc_te_renyi(x = booty,
+                         lx = ly,
+                         y = x,
+                         ly = lx,
+                         q = q)
 
   teboot <- c(dteyx, dtexy)
   names(teboot) <- c("dteyx", "dtexy")

--- a/R/bootstrap_shannon.R
+++ b/R/bootstrap_shannon.R
@@ -7,10 +7,6 @@ bootstrap_shannon <- function(x,
                               y,
                               ly,
                               burn = 50,
-                              constx = NULL,
-                              consty = NULL,
-                              nreps = 2,
-                              shuffles = 6,
                               cl = NULL) {
 
   if (is.null(cl[[1]])) {
@@ -21,60 +17,17 @@ bootstrap_shannon <- function(x,
   bootx <- markov_boot_step(x, lx, burn)
   booty <- markov_boot_step(y, ly, burn)
 
-  if (shuffles > 1) {
-    if (is.null(constx) || is.null(consty)) {
-      # Lead = x
-      dteyx <- calc_te_shannon(x = bootx,
-                               lx = lx,
-                               y = y,
-                               ly = ly) - constx
-      # Lead = y
-      dtexy <- calc_te_shannon(x = booty,
-                               lx = ly,
-                               y = x,
-                               ly = lx) - consty
-    } else {
-      constx <- shuffle_shannon(x = bootx,
-                                lx = lx,
-                                y = y,
-                                ly = ly,
-                                nreps = nreps,
-                                shuffles = shuffles,
-                                diff = TRUE,
-                                cl = cl)
+  # Lead = x
+  dteyx <- calc_te_shannon(x = bootx,
+                           lx = lx,
+                           y = y,
+                           ly = ly)
 
-      consty <- shuffle_shannon(x = booty,
-                                lx = ly,
-                                y = x,
-                                ly = lx,
-                                nreps = nreps,
-                                shuffles = shuffles,
-                                diff = TRUE,
-                                cl = cl)
-
-      # Lead = x
-      dteyx <- calc_te_shannon(x = bootx,
-                               lx = lx,
-                               y = y,
-                               ly = ly) - constx
-      # Lead = y
-      dtexy <- calc_te_shannon(x = booty,
-                               lx = ly,
-                               y = x,
-                               ly = lx) - consty
-    }
-  } else {
-    # Lead = x
-    dteyx <- calc_te_shannon(x = bootx,
-                             lx = lx,
-                             y = y,
-                             ly = ly)
-    # Lead = y
-    dtexy <- calc_te_shannon(x = booty,
-                             lx = ly,
-                             y = x,
-                             ly = lx)
-  }
+  # Lead = y
+  dtexy <- calc_te_shannon(x = booty,
+                           lx = ly,
+                           y = x,
+                           ly = lx)
 
   teboot <- c(dteyx, dtexy)
   names(teboot) <- c("dteyx", "dtexy")

--- a/R/shuffle_renyi.R
+++ b/R/shuffle_renyi.R
@@ -10,7 +10,6 @@ shuffle_renyi <- function(x,
                           q,
                           nreps = 2,
                           shuffles = 6,
-                          diff = TRUE,
                           cl = NULL) {
 
   seeds <- sample(.Machine$integer.max, shuffles)
@@ -27,11 +26,5 @@ shuffle_renyi <- function(x,
 
   ste <- mean(unlist(shuffle))
 
-  if (diff) {
-    te <- calc_te_renyi(x = x, y = y, lx = lx, ly = ly, q) - ste
-  } else {
-    te <- ste
-  }
-
-  return(te)
+  return(ste)
 }

--- a/R/shuffle_shannon.R
+++ b/R/shuffle_shannon.R
@@ -9,7 +9,6 @@ shuffle_shannon <- function(x,
                             ly,
                             nreps = 2,
                             shuffles = 6,
-                            diff = TRUE,
                             cl = NULL) {
 
   seeds <- sample(.Machine$integer.max, shuffles)
@@ -26,11 +25,5 @@ shuffle_shannon <- function(x,
 
   ste <- mean(unlist(shuffle))
 
-  if (diff) {
-    te <- calc_te_shannon(x = x, y = y, lx = lx, ly = ly) - ste
-  } else {
-    te <- ste
-  }
-
-  return(te)
+  return(ste)
 }

--- a/R/te_renyi.R
+++ b/R/te_renyi.R
@@ -6,9 +6,6 @@ te_renyi <- function(x,
                      y,
                      ly,
                      q,
-                     const = FALSE,
-                     constx = 0,
-                     consty = 0,
                      nreps = 2,
                      shuffles = 6,
                      cl = NULL,
@@ -34,7 +31,6 @@ te_renyi <- function(x,
                           q = q,
                           nreps = nreps,
                           shuffles = shuffles,
-                          diff = FALSE,
                           cl = cl)
   stexy <- texy - consty
 
@@ -48,7 +44,6 @@ te_renyi <- function(x,
                           q = q,
                           nreps = nreps,
                           shuffles = shuffles,
-                          diff = FALSE,
                           cl = cl)
   steyx <- teyx - constx
 
@@ -66,10 +61,6 @@ te_renyi <- function(x,
                       ly = ly,
                       q = q,
                       burn = burn,
-                      shuffles = shuffles,
-                      constx = constx,
-                      consty = consty,
-                      nreps = nreps,
                       cl = NULL)
     }, cl = cl)
   } else {

--- a/R/te_shannon.R
+++ b/R/te_shannon.R
@@ -5,9 +5,6 @@ te_shannon <- function(x,
                        lx,
                        y,
                        ly,
-                       const = FALSE,
-                       constx = 0,
-                       consty = 0,
                        nreps = 2,
                        shuffles = 6,
                        cl = NULL,
@@ -32,7 +29,6 @@ te_shannon <- function(x,
                             ly = lx,
                             nreps = nreps,
                             shuffles = shuffles,
-                            diff = FALSE,
                             cl = cl)
   stexy <- texy - consty
 
@@ -45,7 +41,6 @@ te_shannon <- function(x,
                             ly = ly,
                             nreps = nreps,
                             shuffles = shuffles,
-                            diff = FALSE,
                             cl = cl)
   steyx <- teyx - constx
 
@@ -60,10 +55,6 @@ te_shannon <- function(x,
                         y = y,
                         ly = ly,
                         burn = burn,
-                        constx = constx,
-                        consty = consty,
-                        nreps = nreps,
-                        shuffles = shuffles,
                         cl = NULL)
     }, cl = cl)
   } else {

--- a/R/transfer_entropy.R
+++ b/R/transfer_entropy.R
@@ -12,10 +12,6 @@
 #' @param entropy transfer entropy measure that is calculated, either 'Shannon'
 #'                or 'Renyi'; first character can be used as well;
 #'                default is Shannon
-#' @param constx constant value subtracted from transfer entropy measure Y->X;
-#'               default is NULL (no constant value is subtracted)
-#' @param consty constant value subtracted from transfer entropy measure X->Y;
-#'               default is NULL (no constant value is subtracted
 #' @param nreps number of replications for each shuffle; default is 2
 #' @param shuffles number of shuffles; default is 50
 #' @param cl numeric value (default is number of cores - 1),
@@ -69,8 +65,6 @@ transfer_entropy <- function(x,
                              ly = 1,
                              q = 0.1,
                              entropy = "Shannon",
-                             constx = NULL,
-                             consty = NULL,
                              nreps = 2,
                              shuffles = 50,
                              cl = parallel::detectCores() - 1,
@@ -107,11 +101,11 @@ transfer_entropy <- function(x,
   }
 
   # Check/Restrict number of classes and Markov order/lags
-  if (length(quantiles) > 10 || length(bins) > 10 || length(limits) > 10)
-    stop("Number of classes should not exceed 10.")
+  if (length(quantiles) > 20 || length(bins) > 20 || length(limits) > 20)
+    stop("Number of classes should not exceed 20. Do not expect sensical results when using too many classes and/or lags.")
 
-  if (lx > 10 || ly > 10)
-    stop("Markov order/number of lags should not exceed 10.")
+  if (lx > 20 || ly > 20)
+    stop("Markov order/number of lags should not exceed 20. Do not expect sensical results when using too many classes and/or lags.")
 
   # Check that transfer entropy measure is specified correctly
   entropy <- tolower(entropy)
@@ -184,8 +178,6 @@ transfer_entropy <- function(x,
                      lx = lx,
                      y = y,
                      ly = ly,
-                     constx = constx,
-                     consty = consty,
                      nreps = nreps,
                      shuffles = shuffles,
                      cl = cl,
@@ -202,8 +194,6 @@ transfer_entropy <- function(x,
                    y = y,
                    ly = ly,
                    q = q,
-                   constx = constx,
-                   consty = consty,
                    nreps = nreps,
                    shuffles = shuffles,
                    cl = cl,

--- a/man/transfer_entropy.Rd
+++ b/man/transfer_entropy.Rd
@@ -5,10 +5,9 @@
 \title{Calculates Shannon and Renyi transfer entropy between two time series.}
 \usage{
 transfer_entropy(x, y, lx = 1, ly = 1, q = 0.1, entropy = "Shannon",
-  constx = NULL, consty = NULL, nreps = 2, shuffles = 50,
-  cl = parallel::detectCores() - 1, type = "quantiles", quantiles = c(5,
-  95), bins = NULL, limits = NULL, nboot = 300, burn = 50,
-  quiet = FALSE, seed = NULL)
+  nreps = 2, shuffles = 50, cl = parallel::detectCores() - 1,
+  type = "quantiles", quantiles = c(5, 95), bins = NULL, limits = NULL,
+  nboot = 300, burn = 50, quiet = FALSE, seed = NULL)
 }
 \arguments{
 \item{x}{vector of values, ordered by time}
@@ -28,12 +27,6 @@ transfer entropy; default is 0.1}
 \item{entropy}{transfer entropy measure that is calculated, either 'Shannon'
 or 'Renyi'; first character can be used as well;
 default is Shannon}
-
-\item{constx}{constant value subtracted from transfer entropy measure Y->X;
-default is NULL (no constant value is subtracted)}
-
-\item{consty}{constant value subtracted from transfer entropy measure X->Y;
-default is NULL (no constant value is subtracted}
 
 \item{nreps}{number of replications for each shuffle; default is 2}
 


### PR DESCRIPTION
Hier kurz, was ich geändert habe:

- Der Inputparameter `diff` in `shuffle_shannon` und `shuffle_renyi` ist raus. Warum? Mit `shuffle_shannon` und `shuffle_renyi` wird jetzt nur noch der mean über die Shuffles berechnet. Vorher hat `diff` angegeben, ob da gleich eine effective (shuffled) TE berechnet werden soll oder nur der mean über die Shuffles. Das ging dann auch in `bootstrap_shannon` und `bootstrap_renyi` rein (beim Originalcode und bei uns). Gegeben, dass ein Teil des Codes in den Bootstrap-Funktionen nicht angespochen werden konnte (wieder im Originalcode und bei uns der Fall, Issue #36), wurde hier im Bootstrap immer von der neu berechneten TE eine effective (shuffled) TE abgezogen, da `diff = TRUE`. Den Grund dafür verstehe ich nicht, deshalb ist das in dem Update raus.

- Im Bootstrap wird nun nur noch eine ganz normale TE (nicht bias-corrected/effective (shuffled) TE) berechnet. Unsere TE wollen wir ja mit einem Bootstrap-Sample solcher normalen TEs vergleichen.

- `const` (tote Variable), `constx`, `consty` sind  damit raus, weil irrelevant.

- Die Restriktion auf maximal 10 Klassen/Lags habe ich auf 20 gesetzt, mit Kommentar, dass die Ergebnisse bei zu vielen Klassen/Lags nicht mehr sinnvoll sein müssen.

Ein neues Issue hat sich aufgetan:
Ich habe Shannon mit `nboot = 3` durchlaufen lassen (habe nur 4 Cores, mein Laptop ist alt), im Output gab es aber 5 unterschieldiche(!) Werte, für diese 3 Bootstraps. @DavZim Ist das ein Problem mit der Parallelisierung der Berechnungen? Außerdem wurde die Signifikanz nicht richtig erkannt, obwohl die p-values im Code richtig berechnet und zugeordnet werden. Das hängt wohl zusammen.